### PR TITLE
Use environment variable for authgw address with appsettings fallback

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,8 +20,6 @@ jobs:
         run: dotnet restore src/JobsInFinland.Api.Productizer
       - name: Build
         run: dotnet build src/JobsInFinland.Api.Productizer --no-restore
-        env:
-          AuthGwBaseAddress: ${{ secrets.AUTHENTICATION_GW_URL }}
       - name: Publish
         run: dotnet publish src/JobsInFinland.Api.Productizer/JobsInFinland.Api.Productizer.csproj -c Release -o release --nologo
       - name: Upload build artifact

--- a/deployment/JobsInFinlandProductizerStack.cs
+++ b/deployment/JobsInFinlandProductizerStack.cs
@@ -57,6 +57,9 @@ public class JobsInFinlandProductizerStack : Stack
                 PolicyArn = ManagedPolicy.AWSLambdaBasicExecutionRole.ToString()
             });
 
+        var authenticationGatewayRef =
+            new StackReference($"{Deployment.Instance.OrganizationName}/authentication-gw/{environment}");
+
         var lambdaFunction = new Function($"{projectName}-{environment}", new FunctionArgs
         {
             Role = role.Arn,
@@ -67,7 +70,8 @@ public class JobsInFinlandProductizerStack : Stack
             {
                 Variables = new InputMap<string>
                 {
-                    { "ASPNETCORE_ENVIRONMENT", environment }
+                    { "ASPNETCORE_ENVIRONMENT", environment },
+                    { "AUTH_GW_BASE_ADDRESS", authenticationGatewayRef.GetOutput("endpoint").ToString() }
                 }
             },
             Tags = tags,

--- a/deployment/JobsInFinlandProductizerStack.cs
+++ b/deployment/JobsInFinlandProductizerStack.cs
@@ -71,7 +71,7 @@ public class JobsInFinlandProductizerStack : Stack
                 Variables = new InputMap<string>
                 {
                     { "ASPNETCORE_ENVIRONMENT", environment },
-                    { "AUTH_GW_BASE_ADDRESS", authenticationGatewayRef.GetOutput("endpoint").ToString() }
+                    { "AuthGwBaseAddress", authenticationGatewayRef.GetOutput("endpoint").ToString() }
                 }
             },
             Tags = tags,

--- a/src/JobsInFinland.Api.Productizer/Program.cs
+++ b/src/JobsInFinland.Api.Productizer/Program.cs
@@ -18,7 +18,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddHttpClient<IAuthorizationService, AuthorizationService>(client =>
     client.BaseAddress = new Uri(
         builder.Configuration.GetSection("AuthGwBaseAddress").Value ??
-        Environment.GetEnvironmentVariable("AuthGwBaseAddress") ??
+        Environment.GetEnvironmentVariable("AUTH_GW_BASE_ADDRESS") ??
         throw new InvalidOperationException("Missing configuration value for Auth GW API base address")
     )
 );

--- a/src/JobsInFinland.Api.Productizer/Program.cs
+++ b/src/JobsInFinland.Api.Productizer/Program.cs
@@ -18,7 +18,6 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddHttpClient<IAuthorizationService, AuthorizationService>(client =>
     client.BaseAddress = new Uri(
         builder.Configuration.GetSection("AuthGwBaseAddress").Value ??
-        Environment.GetEnvironmentVariable("AUTH_GW_BASE_ADDRESS") ??
         throw new InvalidOperationException("Missing configuration value for Auth GW API base address")
     )
 );

--- a/src/JobsInFinland.Api.Productizer/appsettings.json
+++ b/src/JobsInFinland.Api.Productizer/appsettings.json
@@ -8,6 +8,5 @@
   "AllowedHosts": "*",
   "JobsInFinland": {
     "ApiBaseAddress": "https://jobsinfinland.fi/api/"
-  },
-  "AuthGwBaseAddress": "https://q88uo5prmh.execute-api.eu-north-1.amazonaws.com"
+  }
 }


### PR DESCRIPTION
Ajatuksena tässä tosiaan on sallia productizerin deployaaminen useampaa ympäristöön, ja sitä varten tarvitaan authentication-gateway endpoint oikeasta ympäristöstä. Tuo endpoint voidaan asettaa Lambdan enveihin, ja lukea sieltä sitten dotnet sovelluksessa.

Tuo endpoint pitäisi voida hakea näppärästi Pulumin stack refererencellä, tosin tuosta mietin että onko se ongelmallinen riippuvuus kahden sovelluksen välillä. Vaikka onhan sovelluksilla aina riippuvuus toisistaan... 🤔 