### PR TITLE
Perf/wakeup signal handler

### DIFF
--- a/deployment/JobsInFinlandProductizerStack.cs
+++ b/deployment/JobsInFinlandProductizerStack.cs
@@ -68,6 +68,7 @@ public class JobsInFinlandProductizerStack : Stack
             Runtime = "dotnet6",
             Handler = "JobsInFinland.Api.Productizer",
             Timeout = 15,
+            MemorySize = 1024,
             Environment = new FunctionEnvironmentArgs
             {
                 Variables = new InputMap<string>

--- a/src/JobsInFinland.Api.Productizer.UnitTests/Middleware/AuthGwAuthorizationMiddleware_UnitTests.cs
+++ b/src/JobsInFinland.Api.Productizer.UnitTests/Middleware/AuthGwAuthorizationMiddleware_UnitTests.cs
@@ -22,7 +22,7 @@ public class AuthGwAuthorizationMiddleware_UnitTests
             {
                 builder
                     .UseTestServer()
-                    .ConfigureTestServices(services => { services.AddSingleton<AuthGwOptions>(); })
+                    .ConfigureTestServices(services => { services.AddSingleton<AuthGwRequestOptions>(); })
                     .ConfigureServices(services =>
                     {
                         services.AddSingleton<IAuthorizationService, AuthorizationService>();

--- a/src/JobsInFinland.Api.Productizer.UnitTests/Middleware/AuthGwAuthorizationMiddleware_UnitTests.cs
+++ b/src/JobsInFinland.Api.Productizer.UnitTests/Middleware/AuthGwAuthorizationMiddleware_UnitTests.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Moq;
 
 namespace JobsInFinland.Api.Productizer.UnitTests.Middleware;
 
@@ -23,12 +22,21 @@ public class AuthGwAuthorizationMiddleware_UnitTests
             {
                 builder
                     .UseTestServer()
+                    .ConfigureTestServices(services => { services.AddSingleton<AuthGwOptions>(); })
                     .ConfigureServices(services =>
                     {
                         services.AddSingleton<IAuthorizationService, AuthorizationService>();
                         services.AddHttpClient<IAuthorizationService, AuthorizationService>();
                     })
-                    .Configure(app => app.UseMiddleware<AuthGwAuthorizationMiddleware>());
+                    .Configure(app =>
+                    {
+                        app.UseMiddleware<AuthGwAuthorizationMiddleware>();
+                        app.UseAuthGwAuthorization(options =>
+                        {
+                            var allowed = options.AllowedRequestPaths;
+                            allowed.Add("/wake-up");
+                        });
+                    });
             })
             .StartAsync();
         var actual = await host.GetTestClient().GetAsync("/");

--- a/src/JobsInFinland.Api.Productizer.UnitTests/Middleware/AuthGwHeaderValidationMiddleware_UnitTests.cs
+++ b/src/JobsInFinland.Api.Productizer.UnitTests/Middleware/AuthGwHeaderValidationMiddleware_UnitTests.cs
@@ -22,7 +22,7 @@ public class AuthGwHeaderValidationMiddleware_UnitTests
             {
                 builder
                     .UseTestServer()
-                    .ConfigureTestServices(services => { services.AddSingleton<AuthGwHeaderOptions>(); })
+                    .ConfigureTestServices(services => { services.AddSingleton<AuthGwOptions>(); })
                     .Configure(app =>
                     {
                         app.UseMiddleware<AuthGwHeaderValidationMiddleware>();

--- a/src/JobsInFinland.Api.Productizer.UnitTests/Middleware/AuthGwHeaderValidationMiddleware_UnitTests.cs
+++ b/src/JobsInFinland.Api.Productizer.UnitTests/Middleware/AuthGwHeaderValidationMiddleware_UnitTests.cs
@@ -22,7 +22,7 @@ public class AuthGwHeaderValidationMiddleware_UnitTests
             {
                 builder
                     .UseTestServer()
-                    .ConfigureTestServices(services => { services.AddSingleton<AuthGwOptions>(); })
+                    .ConfigureTestServices(services => { services.AddSingleton<AuthGwRequestOptions>(); })
                     .Configure(app =>
                     {
                         app.UseMiddleware<AuthGwHeaderValidationMiddleware>();

--- a/src/JobsInFinland.Api.Productizer/Middleware/AuthGwAuthorizationMiddleware.cs
+++ b/src/JobsInFinland.Api.Productizer/Middleware/AuthGwAuthorizationMiddleware.cs
@@ -5,14 +5,22 @@ namespace JobsInFinland.Api.Productizer.Middleware;
 public class AuthGwAuthorizationMiddleware
 {
     private readonly RequestDelegate _next;
+    private readonly AuthGwOptions _options;
 
-    public AuthGwAuthorizationMiddleware(RequestDelegate next)
+    public AuthGwAuthorizationMiddleware(RequestDelegate next, AuthGwOptions options)
     {
         _next = next;
+        _options = options;
     }
 
     public async Task Invoke(HttpContext context, IAuthorizationService service)
     {
+        if (_options.AllowedRequestPaths.Any(path => context.Request.Path == path))
+        {
+            await _next.Invoke(context);
+            return;
+        }
+
         try
         {
             await service.Authorize(context.Request);

--- a/src/JobsInFinland.Api.Productizer/Middleware/AuthGwAuthorizationMiddleware.cs
+++ b/src/JobsInFinland.Api.Productizer/Middleware/AuthGwAuthorizationMiddleware.cs
@@ -5,9 +5,9 @@ namespace JobsInFinland.Api.Productizer.Middleware;
 public class AuthGwAuthorizationMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly AuthGwOptions _options;
+    private readonly AuthGwRequestOptions _options;
 
-    public AuthGwAuthorizationMiddleware(RequestDelegate next, AuthGwOptions options)
+    public AuthGwAuthorizationMiddleware(RequestDelegate next, AuthGwRequestOptions options)
     {
         _next = next;
         _options = options;

--- a/src/JobsInFinland.Api.Productizer/Middleware/AuthGwBuilderExtensions.cs
+++ b/src/JobsInFinland.Api.Productizer/Middleware/AuthGwBuilderExtensions.cs
@@ -4,25 +4,30 @@ namespace JobsInFinland.Api.Productizer.Middleware;
 
 public static class AuthGwBuilderExtensions
 {
-    public static IApplicationBuilder UseAuthGwAuthorization(this IApplicationBuilder builder)
+    public static IApplicationBuilder UseAuthGwAuthorization(this IApplicationBuilder builder, Action<AuthGwOptions>? setupAction)
     {
-        return builder.UseMiddleware<AuthGwAuthorizationMiddleware>();
+        AuthGwOptions options;
+        using (var scope = builder.ApplicationServices.CreateScope())
+        {
+            options = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<AuthGwOptions>>().Value;
+            setupAction?.Invoke(options);
+        }
+        return builder.UseMiddleware<AuthGwAuthorizationMiddleware>(options);
     }
 
-
     private static IApplicationBuilder UseAuthGwHeaderValidation(this IApplicationBuilder builder,
-        AuthGwHeaderOptions options)
+        AuthGwOptions options)
     {
         return builder.UseMiddleware<AuthGwHeaderValidationMiddleware>(options);
     }
 
     public static IApplicationBuilder UseAuthGwHeaderValidation(this IApplicationBuilder builder,
-        Action<AuthGwHeaderOptions>? setupAction)
+        Action<AuthGwOptions>? setupAction)
     {
-        AuthGwHeaderOptions options;
+        AuthGwOptions options;
         using (var scope = builder.ApplicationServices.CreateScope())
         {
-            options = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<AuthGwHeaderOptions>>().Value;
+            options = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<AuthGwOptions>>().Value;
             setupAction?.Invoke(options);
         }
 

--- a/src/JobsInFinland.Api.Productizer/Middleware/AuthGwBuilderExtensions.cs
+++ b/src/JobsInFinland.Api.Productizer/Middleware/AuthGwBuilderExtensions.cs
@@ -4,30 +4,30 @@ namespace JobsInFinland.Api.Productizer.Middleware;
 
 public static class AuthGwBuilderExtensions
 {
-    public static IApplicationBuilder UseAuthGwAuthorization(this IApplicationBuilder builder, Action<AuthGwOptions>? setupAction)
+    public static IApplicationBuilder UseAuthGwAuthorization(this IApplicationBuilder builder, Action<AuthGwRequestOptions>? setupAction)
     {
-        AuthGwOptions options;
+        AuthGwRequestOptions options;
         using (var scope = builder.ApplicationServices.CreateScope())
         {
-            options = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<AuthGwOptions>>().Value;
+            options = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<AuthGwRequestOptions>>().Value;
             setupAction?.Invoke(options);
         }
         return builder.UseMiddleware<AuthGwAuthorizationMiddleware>(options);
     }
 
     private static IApplicationBuilder UseAuthGwHeaderValidation(this IApplicationBuilder builder,
-        AuthGwOptions options)
+        AuthGwRequestOptions options)
     {
         return builder.UseMiddleware<AuthGwHeaderValidationMiddleware>(options);
     }
 
     public static IApplicationBuilder UseAuthGwHeaderValidation(this IApplicationBuilder builder,
-        Action<AuthGwOptions>? setupAction)
+        Action<AuthGwRequestOptions>? setupAction)
     {
-        AuthGwOptions options;
+        AuthGwRequestOptions options;
         using (var scope = builder.ApplicationServices.CreateScope())
         {
-            options = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<AuthGwOptions>>().Value;
+            options = scope.ServiceProvider.GetRequiredService<IOptionsSnapshot<AuthGwRequestOptions>>().Value;
             setupAction?.Invoke(options);
         }
 

--- a/src/JobsInFinland.Api.Productizer/Middleware/AuthGwHeaderValidationMiddleware.cs
+++ b/src/JobsInFinland.Api.Productizer/Middleware/AuthGwHeaderValidationMiddleware.cs
@@ -5,9 +5,9 @@ namespace JobsInFinland.Api.Productizer.Middleware;
 public class AuthGwHeaderValidationMiddleware
 {
     private readonly RequestDelegate _next;
-    private readonly AuthGwOptions _options;
+    private readonly AuthGwRequestOptions _options;
 
-    public AuthGwHeaderValidationMiddleware(RequestDelegate next, AuthGwOptions options)
+    public AuthGwHeaderValidationMiddleware(RequestDelegate next, AuthGwRequestOptions options)
     {
         _next = next;
         _options = options;

--- a/src/JobsInFinland.Api.Productizer/Middleware/AuthGwOptions.cs
+++ b/src/JobsInFinland.Api.Productizer/Middleware/AuthGwOptions.cs
@@ -1,6 +1,7 @@
 namespace JobsInFinland.Api.Productizer.Middleware;
 
-public class AuthGwHeaderOptions
+public class AuthGwOptions
 {
     public List<string> RequiredHeaders { get; } = new();
+    public List<string> AllowedRequestPaths { get; set; } = new();
 }

--- a/src/JobsInFinland.Api.Productizer/Middleware/AuthGwRequestOptions.cs
+++ b/src/JobsInFinland.Api.Productizer/Middleware/AuthGwRequestOptions.cs
@@ -1,6 +1,6 @@
 namespace JobsInFinland.Api.Productizer.Middleware;
 
-public class AuthGwOptions
+public class AuthGwRequestOptions
 {
     public List<string> RequiredHeaders { get; } = new();
     public List<string> AllowedRequestPaths { get; set; } = new();

--- a/src/JobsInFinland.Api.Productizer/Program.cs
+++ b/src/JobsInFinland.Api.Productizer/Program.cs
@@ -47,17 +47,28 @@ if (app.Environment.IsEnvironment("Local"))
     app.UseSwagger();
     app.UseSwaggerUI();
 }
+else
+{
+    app.UseHttpsRedirection();
+}
 
-app.UseHttpsRedirection();
+
+
+// Paths that are allowed to be accessed without authorization
+List<string> allowedRequestPaths = new List<string> { "/wake-up" };
 
 app.UseAuthGwHeaderValidation(options =>
 {
     var optionsRequiredHeaders = options.RequiredHeaders;
     optionsRequiredHeaders.Add("authorization");
+    options.AllowedRequestPaths = allowedRequestPaths;
 });
 if (!app.Environment.IsEnvironment("Local"))
 {
-    app.UseAuthGwAuthorization();
+    app.UseAuthGwAuthorization(options =>
+    {
+        options.AllowedRequestPaths = allowedRequestPaths;
+    });
 }
 
 app.MapPost("test/lassipatanen/Job/JobPosting", async (
@@ -70,7 +81,7 @@ app.MapPost("test/lassipatanen/Job/JobPosting", async (
         {
             return Results.ValidationProblem(errors: validationResult.ToDictionary(), statusCode: 422);
         }
-        
+
         IList<Job> queryResult;
 
         try
@@ -81,7 +92,7 @@ app.MapPost("test/lassipatanen/Job/JobPosting", async (
         {
             var statusCode = 500;
             if (e.StatusCode != null) statusCode = (int)e.StatusCode;
-            
+
             return Results.Problem(e.ToString(), statusCode: statusCode);
         }
 
@@ -102,5 +113,12 @@ app.MapPost("test/lassipatanen/Job/JobPosting", async (
     .Produces<ValidationProblemDetails>(422)
     .Produces(500)
     .WithName("FindJobPostings");
+
+app.MapGet("/wake-up", () =>
+{
+    return Task.FromResult(Results.Ok());
+})
+    .Produces(200)
+    .WithName("WakeUp");
 
 app.Run();


### PR DESCRIPTION
- Add a `/wake-up` route: a wake signal handler that just wakes the lambda function from a cold boot state
    - used to speedup the demo application lists loading times
- add a route path whitelist for the authorization middlewares, with `/wake-up` in the allowed path values
- upgrade lambda instance max memory from 128mb to 1024mb for a request handling speed increase (~13s -> ~2s)
- use UseHttpsRedirection middleware only on live environments as there is no local SSL termination in the current setup